### PR TITLE
Credentials

### DIFF
--- a/content/doctypes/credentials.md
+++ b/content/doctypes/credentials.md
@@ -8,17 +8,19 @@ Background information (the why) concerning `credentials`:
 * Each `credential` has a `nymIDSource` and three key's (`A`, `E`, `S`).
   * The `nymID` (Identifier) is based on the hash of the `nymIDSource`. A nym consists of all credentials (master and key credentials). 
   * The `nymIDSource` is the "root" of the trust-chain. It can be anything that can authenticate the `masterCredential`.
+    Insecure example for illustration: if the `nymIDSource` was an url, http://monetas-authenticator.monetas.org/, you would check if that url returns the master credential `ID`. If it does,
+    the master credential is authenticated.
     * The same `nymIDSource` is shared between the `masterCredential` as well as any `keyCredential`. This is how you know they are part of the same nym (`nymID`).
-    * Currently, only self-signing is supported (`nymIDSource` = public key). In the future, Bitcoin addresses, Namecoin addresses, X.509 etc. could be integrated.
+    * Currently, only self-signing is supported (`nymIDSource` = `masterCredential`'s S-key). In the future, Bitcoin addresses, Namecoin addresses, X.509 etc. could be integrated.
   * The `nymIDSource` is used to authenticate  the `masterCredential`, including the A/E/S keys. The `S`-key is used for any further signing action.
   * The credential `ID` is based on the hash of the whole armored `<credential>` contents,
-    which is signed by the credential's `S`-key. (TODO: is the hash based on the signed or non-signed data?).
+    which is self-signed by the credential's `S`-key. (TODO: is the hash based on the signed or non-signed data?).
   * Key types: either `A` (authentication), `E` (encryption) or `S` (signature).
     * Only `S` seems to be in use (TODO: investigate).
     * RSA public keys at the moment, but see [NEW MEP TODO](TODO).
-* The `masterCredential` is self-signed, the whole `masterCredential` document along with its signature is enclosed in the `credential` document.
+* The self-signed `masterCredential` document is enclosed in the `credential` document.
   * (look for the `BEGIN MASTER KEY CREDENTIAL SIGNATURE` section).
-  * The `masterCredential`'s `S`-key is used to sign the `keyCredential` (see `masterSigned`).
+  * The `masterCredential`'s `S`-key is used to sign the `keyCredential` (see `masterSigned`), to authenticate that keycredential.
 * There is an "outer" `keyCredential` document, as well as another `keyCredential` document nested inside. [Confusing naming is confusing.](#possibleimprovements)
 * The outer `keyCredential` is, like the `masterCredential`, a self-signed document. It contains `masterSigned`.
   * `masterSigned` contains the "real", **inner** `keyCredential` document and a signature thereof, made by the `masterCredential`'s `S`-key.

--- a/content/doctypes/credentials.md
+++ b/content/doctypes/credentials.md
@@ -83,3 +83,6 @@ Signed by the keys contained in `<masterPublic>`.
   => Remove one layer. Remove the outer `keyCredential`
 * Remove `masterPublic`, replace it by providing the `masterID` only. This is sufficient to prove that the master signed the keyCredential (as it is still inside `masterSigned`, with the master's signature).
 * TODO (for Otto to fill out): Why could we remove the `masterCredential` document, as discussed in the hangout?
+* Remove self-signing: it does not matter if there is proof of the private key, when looked at the credentials in isolation.
+  However, you can't register credentials without signing off on the document, and cannot use the credential anywhere else either without a signature. Self-signing of credentials adds nothing. It complicates the whole structure, parsing, writing.
+* Flatten the chain of trust: at the moment, the nymIDSource authenticates the master's A/E/S keys, and the S-key authenticates the subkeys, which also have A/E/S keys. There should be one master source only (either a pubkey or any other nym source), that authenticates subkeys, one for each type (A/E/S). (Not multiple subkeys, which each have A/E/S). That way, you can revoke keys individually, instead of A/E/S-bundles. This way, we would drop the master A/E/S keys, and use the nym source to directly authenticate subkeys of different types.

--- a/content/doctypes/credentials.md
+++ b/content/doctypes/credentials.md
@@ -1,5 +1,40 @@
 # Document Types Related to Credential System
 
+Example of the doctypes can be found inside the [registerNym example](registerNym.xml).
+
+See also [this colored representation](https://drive.google.com/a/monetas.net/file/d/0Bztm5gBf7t8xMUFHTXd0UzF3dXM/view), courtesy of Justus Raniver.
+Background information (the why) concerning `credentials`:
+
+* Each `credential` has a `nymIDSource` and three key's (`A`, `E`, `S`).
+  * The `nymID` (Identifier) is based on the hash of the `nymIDSource`. A nym consists of all credentials (master and key credentials). 
+  * The `nymIDSource` is the "root" of the trust-chain. It can be anything that can authenticate the `masterCredential`.
+    * The same `nymIDSource` is shared between the `masterCredential` as well as any `keyCredential`. This is how you know they are part of the same nym (`nymID`).
+    * Currently, only self-signing is supported (`nymIDSource` = public key). In the future, Bitcoin addresses, Namecoin addresses, X.509 etc. could be integrated.
+  * The `nymIDSource` is used to authenticate  the `masterCredential`, including the A/E/S keys. The `S`-key is used for any further signing action.
+  * The credential `ID` is based on the hash of the whole armored `<credential>` contents,
+    which is signed by the credential's `S`-key. (TODO: is the hash based on the signed or non-signed data?).
+  * Key types: either `A` (authentication), `E` (encryption) or `S` (signature).
+    * Only `S` seems to be in use (TODO: investigate).
+    * RSA public keys at the moment, but see [NEW MEP TODO](TODO).
+* The `masterCredential` is self-signed, the whole `masterCredential` document along with its signature is enclosed in the `credential` document.
+  * (look for the `BEGIN MASTER KEY CREDENTIAL SIGNATURE` section).
+  * The `masterCredential`'s `S`-key is used to sign the `keyCredential` (see `masterSigned`).
+* There is an "outer" `keyCredential` document, as well as another `keyCredential` document nested inside. [Confusing naming is confusing.](#possibleimprovements)
+* The outer `keyCredential` is, like the `masterCredential`, a self-signed document. It contains `masterSigned`.
+  * `masterSigned` contains the "real", **inner** `keyCredential` document and a signature thereof, made by the `masterCredential`'s `S`-key.
+  * General concept: Master source (`nymIDSource`) authenticates the `masterCredential`'s A/E/S keys. That `S`-key in turn signs the `keyCredential`. 
+  * `nymIDSource`: Copy of the `masterCredential`'s `nymIDSource`.
+  * The **inner** `keyCredential` is just like any other credential, coming with `nymIDSource` and A/E/S keys.
+    In addition, it contains the full self-signed `masterCredential` document (a 1:1 copy of the signed `masterCredential` document, enclosed in `masterPublic`).
+    Why? The reason is that the `keyCredential` should contain the information of the master that signed it, and the master's signature to prove it has been signed.
+    **Possible improvement**: Enclose only the `masterCredential`'s credential-`ID` instead of the full thing. 
+
+FAQ:
+* Q. Why is each credential self-signed? A. To prove that the credential's private key exists.
+* Q. Why does `credentialList` exist along with the [`<nymData>` document](nymData.md)? A. Contains `valid=true/false`, which could be used to revoke keys (TODO: used?).
+  * TODO: The whole message is (presumably) signed by the keyCredential's `S`-key. How can that signature be allowed revoke the `masterCredential`? Shouldn't only something signed by the master be able to revoke subkeys?
+
+
 ## Document Type `<masterCredential>`
 
 * Attribute `nymID`. Identifier.
@@ -13,7 +48,7 @@
 #### When in `<credentials>/<credential>`
 
 * Attribute `nymID`. Identifier.
-* Attribute `masterID`. Identifier.
+* Attribute `masterID`. Identifier. Credential ID of the `masterCredential`.
 * Element `nymIDSource`. String.
 * Element `masterSigned`. Armored version of this document that is signed by
   master credentials.
@@ -42,3 +77,9 @@ Signed by the keys contained in `<masterPublic>`.
       (signature).
   * Contains armored public key.
 
+### Possible Improvements
+* Disambiguate the two different `keyCredential` documents by renaming the "outer" one.
+* The outer `keyCredential`'s `nymIDSource` can be removed, as it also appears nested in `masterSigned`.
+  => Remove one layer. Remove the outer `keyCredential`
+* Remove `masterPublic`, replace it by providing the `masterID` only. This is sufficient to prove that the master signed the keyCredential (as it is still inside `masterSigned`, with the master's signature).
+* TODO (for Otto to fill out): Why could we remove the `masterCredential` document, as discussed in the hangout?

--- a/content/doctypes/notaryMessage.md
+++ b/content/doctypes/notaryMessage.md
@@ -48,9 +48,11 @@ For example, it could be a master credential and four sub credentials, or two
 master credentials and two separate credential.
 
 * Element `credentialIDs`: Contains armored [`<nymData>` document](nymData.md).
-* Element `credentials`: List of credentials mentioned in `credentialIDs`
+* Element `credentials`: List of credentials mentioned in `credentialIDs`. [More infos](credentials.md)
   * Element `credential`: Armored signed credential (document `keyCredential` or `masterCredential`)
-    * Attribute `ID`: credential ID
+  * Attribute `ID`: credential ID
+
+Example document (dearmored, for readability) can be found [here](registerNym.xml).
 
 ### registerNymResponse
 

--- a/content/doctypes/registerNym.xml
+++ b/content/doctypes/registerNym.xml
@@ -1,0 +1,234 @@
+<registerNym requestNum="1" nymID="otxGx6Tk45kgtttrV3MLYHSkDA2mhzgSnLJ5" notaryID="otxB4evbDRgp12gvxayA7yT1d4tUUU8rcLdX">
+  <credentialList>
+    <!-- dearmored 765 bytes -->
+    <nymData version="1.0" nymID="otxGx6Tk45kgtttrV3MLYHSkDA2mhzgSnLJ5">
+      <nymIDSource>
+        <!-- dearmored 426 bytes -->
+        - -----BEGIN PUBLIC KEY-----
+        LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+        UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+        V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+        TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+        NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+        SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+        - -----END PUBLIC KEY-----
+      </nymIDSource>
+      <masterCredential ID="otxQ9JqiT6vV4AkL9N41DDjoF9grz22gUJ1F" valid="true">
+      </masterCredential>
+      <keyCredential ID="otxQMnWauJs5hGRxuc8dWvomfoNAMV48PP7S" masterID="otxQ9JqiT6vV4AkL9N41DDjoF9grz22gUJ1F" valid="true">
+      </keyCredential>
+    </nymData>
+  </credentialList>
+  <credentials>
+    <credential ID="otxQ9JqiT6vV4AkL9N41DDjoF9grz22gUJ1F">
+      <!-- dearmored 2508 bytes -->
+      -----BEGIN SIGNED MASTER KEY CREDENTIAL-----
+      Hash: HASH256
+      <masterCredential nymID="otxGx6Tk45kgtttrV3MLYHSkDA2mhzgSnLJ5">
+        <nymIDSource>
+          <!-- dearmored 426 bytes -->
+          - -----BEGIN PUBLIC KEY-----
+          LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+          UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+          V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+          TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+          NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+          SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+          - -----END PUBLIC KEY-----
+        </nymIDSource>
+        <publicContents count="3">
+          <publicInfo key="A">
+            <!-- dearmored 422 bytes -->
+            -----BEGIN PUBLIC KEY-----
+            LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+            UVVBQTRHTkFEQ0JpUUtCZ1FDbGhuaWJaQ2NjdUpMUWhrcUdoQW9WK0hZNwpiMU9L
+            bmVGcG9wdmQwNmdsOE4zZTVxREhmZ1dmMWViMGxPRnpIZHJVUngwV1l2S1NxbDdq
+            Q24zQkFGWkI5NWFtCkd0N3V6MkZFYUVGZWpZemtqWUw5WEdSZG4vbzBpcnNqYnBa
+            TW1SL3VxNGI3YUFXYlZRdEE4djRBWC9UOXVlYTgKdURUWURjVGJyUGdObmFFOThR
+            SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+            -----END PUBLIC KEY-----
+          </publicInfo>
+          <publicInfo key="E">
+            <!-- dearmored 422 bytes -->
+            -----BEGIN PUBLIC KEY-----
+            LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+            UVVBQTRHTkFEQ0JpUUtCZ1FERkJWME1JMUoxay9jZk5IZ1Nibm9OcWpCUwp1b3Ez
+            ZGhPaUtYVzlheWl3NWxHOVBMTVBMbUMzbFJVZWVlZ2NCUEUxdDc4cE1vU2l4ZlJ2
+            WTB2OWpsQjFNYzRUCmVha1pTSklKUkQ0MzBBeFZJRXBFSDVyMDNCd09ZdWs3MW4v
+            SDV1Z01RN21ReVUvS01oOVUxaHFHa01WZERjYVcKeHhiNG1SMk94YTJ4dXpmT0FR
+            SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+            -----END PUBLIC KEY-----
+          </publicInfo>
+          <publicInfo key="S">
+            <!-- dearmored 422 bytes -->
+            -----BEGIN PUBLIC KEY-----
+            LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+            UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+            V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+            TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+            NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+            SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+            -----END PUBLIC KEY-----
+          </publicInfo>
+        </publicContents>
+      </masterCredential>
+      -----BEGIN MASTER KEY CREDENTIAL SIGNATURE-----
+      Version: Open Transactions 0.94.0-458-g8e4f98a
+      Comment: http://github.com/FellowTraveler/Open-Transactions/wiki
+      
+      MTrFAmlSogz0bSD1Yqt1GFKMwWaJOVntitDIlw6tO4b/DI3vnc7V/GLhKj8Zd1wL
+      E23AyQyfeTfhr7Tl/6GYwWhoZ3/2W0uc96MbX4lYy6+g9aIYD22/9RogZYl07hnE
+      Xm0LUvT4NXtR8EFaA+gPmJTnjPfhSE/BOQ4U/rVC6pM=
+      -----END MASTER KEY CREDENTIAL SIGNATURE-----
+    </credential>
+    <credential ID="otxQMnWauJs5hGRxuc8dWvomfoNAMV48PP7S">
+      <!-- dearmored 6080 bytes -->
+      -----BEGIN SIGNED KEY CREDENTIAL-----
+      Hash: HASH256
+      <keyCredential nymID="otxGx6Tk45kgtttrV3MLYHSkDA2mhzgSnLJ5" masterID="otxQ9JqiT6vV4AkL9N41DDjoF9grz22gUJ1F">
+        <nymIDSource>
+          <!-- dearmored 426 bytes -->
+          - -----BEGIN PUBLIC KEY-----
+          LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+          UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+          V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+          TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+          NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+          SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+          - -----END PUBLIC KEY-----
+        </nymIDSource>
+        <masterSigned>
+          <!-- dearmored 4977 bytes -->
+          -----BEGIN SIGNED KEY CREDENTIAL-----
+          Hash: HASH256
+          <keyCredential nymID="otxGx6Tk45kgtttrV3MLYHSkDA2mhzgSnLJ5" masterID="otxQ9JqiT6vV4AkL9N41DDjoF9grz22gUJ1F">
+            <nymIDSource>
+              <!-- dearmored 426 bytes -->
+              - -----BEGIN PUBLIC KEY-----
+              LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+              UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+              V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+              TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+              NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+              SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+              - -----END PUBLIC KEY-----
+            </nymIDSource>
+            <masterPublic>
+              <!-- dearmored 2508 bytes -->
+              -----BEGIN SIGNED MASTER KEY CREDENTIAL-----
+              Hash: HASH256
+              <masterCredential nymID="otxGx6Tk45kgtttrV3MLYHSkDA2mhzgSnLJ5">
+                <nymIDSource>
+                  <!-- dearmored 426 bytes -->
+                  - -----BEGIN PUBLIC KEY-----
+                  LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                  UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+                  V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+                  TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+                  NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+                  SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                  - -----END PUBLIC KEY-----
+                </nymIDSource>
+                <publicContents count="3">
+                  <publicInfo key="A">
+                    <!-- dearmored 422 bytes -->
+                    -----BEGIN PUBLIC KEY-----
+                    LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                    UVVBQTRHTkFEQ0JpUUtCZ1FDbGhuaWJaQ2NjdUpMUWhrcUdoQW9WK0hZNwpiMU9L
+                    bmVGcG9wdmQwNmdsOE4zZTVxREhmZ1dmMWViMGxPRnpIZHJVUngwV1l2S1NxbDdq
+                    Q24zQkFGWkI5NWFtCkd0N3V6MkZFYUVGZWpZemtqWUw5WEdSZG4vbzBpcnNqYnBa
+                    TW1SL3VxNGI3YUFXYlZRdEE4djRBWC9UOXVlYTgKdURUWURjVGJyUGdObmFFOThR
+                    SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                    -----END PUBLIC KEY-----
+                  </publicInfo>
+                  <publicInfo key="E">
+                    <!-- dearmored 422 bytes -->
+                    -----BEGIN PUBLIC KEY-----
+                    LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                    UVVBQTRHTkFEQ0JpUUtCZ1FERkJWME1JMUoxay9jZk5IZ1Nibm9OcWpCUwp1b3Ez
+                    ZGhPaUtYVzlheWl3NWxHOVBMTVBMbUMzbFJVZWVlZ2NCUEUxdDc4cE1vU2l4ZlJ2
+                    WTB2OWpsQjFNYzRUCmVha1pTSklKUkQ0MzBBeFZJRXBFSDVyMDNCd09ZdWs3MW4v
+                    SDV1Z01RN21ReVUvS01oOVUxaHFHa01WZERjYVcKeHhiNG1SMk94YTJ4dXpmT0FR
+                    SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                    -----END PUBLIC KEY-----
+                  </publicInfo>
+                  <publicInfo key="S">
+                    <!-- dearmored 422 bytes -->
+                    -----BEGIN PUBLIC KEY-----
+                    LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                    UVVBQTRHTkFEQ0JpUUtCZ1FEWlJjZzhLeC9TTnBldExEOTlvK1pWb1VnNwpoKytq
+                    V1RHNTBQZEJLRXlFendDWENSMzBLbGJiUU9HSExSNG1VNFhlOGJFMFJBN2lJd1Rw
+                    TDhyRXdWbFlYMVMzCmFHYVRnWGpUMExlWndSZEdmeEl0V012ZmUrZ1ppRUFOZ3Vv
+                    NmxBQzFJMHJCTnZOaHcyVnFEcEZDb0hFNDBWNk4KdDFPYWZXdXZpMTUrZWVralh3
+                    SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                    -----END PUBLIC KEY-----
+                  </publicInfo>
+                </publicContents>
+              </masterCredential>
+              -----BEGIN MASTER KEY CREDENTIAL SIGNATURE-----
+              Version: Open Transactions 0.94.0-458-g8e4f98a
+              Comment: http://github.com/FellowTraveler/Open-Transactions/wiki
+              
+              MTrFAmlSogz0bSD1Yqt1GFKMwWaJOVntitDIlw6tO4b/DI3vnc7V/GLhKj8Zd1wL
+              E23AyQyfeTfhr7Tl/6GYwWhoZ3/2W0uc96MbX4lYy6+g9aIYD22/9RogZYl07hnE
+              Xm0LUvT4NXtR8EFaA+gPmJTnjPfhSE/BOQ4U/rVC6pM=
+              -----END MASTER KEY CREDENTIAL SIGNATURE-----
+            </masterPublic>
+            <publicContents count="3">
+              <publicInfo key="A">
+                <!-- dearmored 422 bytes -->
+                -----BEGIN PUBLIC KEY-----
+                LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                UVVBQTRHTkFEQ0JpUUtCZ1FESm9XdXNqRGtZTXlieVVxN3ZSRUpTenVQMgpyY0Jj
+                ZW9BVDcybWlBM3FZQUxrT0k0Q05DSkFGeTM2NlFXdTFoRDRGYUZMKzE0YXJyNWJS
+                TnhDeXJxUGxwZmlhCndlY3dNNWN6MVdxOWgzZ0QxNktEVnFJakhLWDNmUitpRHZ6
+                RU1DVUR5T0w0a0M1Q2w0WWNxTFRJMVJIdzVLYmUKQ2JWZW83YWlSK2Q3Z0hwd1p3
+                SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                -----END PUBLIC KEY-----
+              </publicInfo>
+              <publicInfo key="E">
+                <!-- dearmored 422 bytes -->
+                -----BEGIN PUBLIC KEY-----
+                LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                UVVBQTRHTkFEQ0JpUUtCZ1FETmQvaXBKSXNVK2ovaE03L0R3UUhOTGlyagpvVHBi
+                UzhsbkMxblBLV2krR04wejRtT25OREZqdzNQQTFybm96UTFvQk02NVNUUWF5d3BX
+                bjRkZXEzSjRhNGN3Ckx4S3BDUElxS0M2YlVma2Q2RDdhUktvOWhOL1dlbG14d1Bp
+                all4d244ZHBZKzFDZk9EcG5pQXUvWFVqZW9uWFIKOVpiVVpxMklZM3czRnVUR3d3
+                SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                -----END PUBLIC KEY-----
+              </publicInfo>
+              <publicInfo key="S">
+                <!-- dearmored 422 bytes -->
+                -----BEGIN PUBLIC KEY-----
+                LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJB
+                UVVBQTRHTkFEQ0JpUUtCZ1FDdVdDeFpFUWtNQzBPUXlBNGlnWmw3dkU1UQoxK2k3
+                ZDZDZHd4WitlMUlObGRvdm5va2Voc3RoNDFTdlptS1dBbzNkcnJuNGdmWjN0ejFh
+                Q24xOUdxeHpOUWRlCkNtM0EzUmVvQmtxMkUwcTJJZkdNM3VZb0hTSFVTa0t4N28w
+                bUlLNWhVT1BIbkdBemxUVEdRc2JqaDJHRzlsei8Kck9qbGpLTTUyeXZWd25Od0p3
+                SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+                -----END PUBLIC KEY-----
+              </publicInfo>
+            </publicContents>
+          </keyCredential>
+          -----BEGIN KEY CREDENTIAL SIGNATURE-----
+          Version: Open Transactions 0.94.0-458-g8e4f98a
+          Comment: http://github.com/FellowTraveler/Open-Transactions/wiki
+          Meta:    SGQQ
+          
+          NeV0UxQRlpfEPxbNJsmxW1GwdpN1RGAVaqSePAyrG3/I3ooFmquG9SKhoBpIQjFL
+          hQsZQvGaUXgB6SG2DYYc62mblmY/faUoZomXKACjRn1psnShCDXMHFLryFqrVB0F
+          zHZwVtn7mQVHjedvRQW2QiuXPo92nCcBOCSFH0lxdTo=
+          -----END KEY CREDENTIAL SIGNATURE-----
+        </masterSigned>
+      </keyCredential>
+      -----BEGIN KEY CREDENTIAL SIGNATURE-----
+      Version: Open Transactions 0.94.0-458-g8e4f98a
+      Comment: http://github.com/FellowTraveler/Open-Transactions/wiki
+      
+      Z6l02+Ys5DH9BWU2HXIGa3VGkqH5dYMgiV7DD6/h+6+M28HinMY3lAU3AEdQWPmN
+      KXWZzYD2eRQifPYc/XFKnxLBiEyY5/nRQBcmDVpiGRbVarXpspiUZLvlxakiPXS3
+      T2KQ2UA7yvK5ISNdF6huzbDWHXqi3KlmL0/AWevZ0RE=
+      -----END KEY CREDENTIAL SIGNATURE-----
+    </credential>
+  </credentials>
+</registerNym>


### PR DESCRIPTION
Extended documentation, tried to add a bit of a higher level understanding.

@OttoAllmendinger I tried to figure out how we could remove the `masterCredential` document, but could not reconstruct the reason. Care to write it down again? 

As I see it, the master nymIDSource authenticates the master A/E/S keys. The master S-key authenticates the keycredential. Keycredential's S-key is used for signing messages etc. So I don't remember anymore how it would be possible to remove `masterCredential`.