### PR TITLE
Updates reference

### DIFF
--- a/content/doctypes/account.md
+++ b/content/doctypes/account.md
@@ -2,13 +2,13 @@
 
 ## Elements and attributes
 
-* Attribute `type`. String. TODO
-* Attribute `version`. Integer?
+* Attribute `type`. String. Many possible [values](https://github.com/Open-Transactions/opentxs/blob/3204ab5fe31afbb2b6b4456ef8dc860b5658884e/src/core/Account.cpp#L163). Relevant now are `issuer` and `simple`.
+* Attribute `version`. String. [Hardcoded](https://github.com/Open-Transactions/opentxs/blob/3204ab5fe31afbb2b6b4456ef8dc860b5658884e/src/core/Contract.cpp#L241) to `2.0`.
 * Attribute `accountID`. Identifier.
 * Attribute `nymID`. Identifier.
 * Attribute `notaryID`. Identifier.
 * Attribute `instrumentDefinitionID`. Identifier.
-* Optional element `stashinfo` (optional)
+* Optional element `stashinfo`.
     * Attribute `cronItemNum`. Integer. Never set anywhere in the old code.
       Probably dead code.
 * Optional element `inboxHash value`. Only included after at least one

--- a/content/doctypes/account.md
+++ b/content/doctypes/account.md
@@ -39,4 +39,4 @@
 
 ## References
 
-[Account::UpdateContents()](https://github.com/Open-Transactions/opentxs/blob/d032df5e2012ca15be9d09231e46e4a28c6cd51c/src/core/Account.cpp#l749)
+[Account::UpdateContents()](https://github.com/Open-Transactions/opentxs/blob/3204ab5fe31afbb2b6b4456ef8dc860b5658884e/src/core/Account.cpp#L741)


### PR DESCRIPTION
Some refactoring has been done and the link no longer pointed to the correct location.

`assetAccount` has been renamed to `account`.